### PR TITLE
Use call instead of execute before system to run external commands

### DIFF
--- a/autoload/investigate.vim
+++ b/autoload/investigate.vim
@@ -95,7 +95,7 @@ function! investigate#Investigate()
   endif
 
   if l:command =~ s:Executable()
-    execute system(l:command)
+    call system(l:command)
   else
     try
       silent execute l:command


### PR DESCRIPTION
Before this commit, calling of investigate produced `E492: Not an editor command` error.

For example I got this error in `:message` for bash files:
`Not an editor command: firefox https://encrypted.google.com/search?q=exec&sitesearch=ss64.com^@`
