### PR TITLE
Add alias for Less syntax

### DIFF
--- a/autoload/investigate/defaults.vim
+++ b/autoload/investigate/defaults.vim
@@ -43,6 +43,7 @@ let s:defaultLocations = {
 let s:syntaxAliases = {
   \ "bash": "sh",
   \ "help": "vim",
+  \ "less": "css",
   \ "pythondjango": "django",
   \ "sass": "css",
   \ "scsscss": "css",


### PR DESCRIPTION
Less files are not recognized, but since they’re basically CSS-files, just like Sass, adding an alias solves this.
