### PR TITLE
Update the Sass aliases

### DIFF
--- a/autoload/investigate/defaults.vim
+++ b/autoload/investigate/defaults.vim
@@ -47,6 +47,7 @@ let s:syntaxAliases = {
   \ "pythondjango": "django",
   \ "sass": "css",
   \ "scss": "css",
+  \ "scsscss": "css",
   \ "specta": "objc",
   \ "zsh": "sh"
 \ }


### PR DESCRIPTION
The most common (or at least it should be) file type for SCSS files is `scss`, and should be a default alias.

As I said in #11, let me know if you find any other SCSS (or Sass) file types that should be included.
